### PR TITLE
Bugfix: images sizes for carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
             <div class="col-lg-7 col-md-5">
 
               <div class="box-container">
-                <img src="/img/bg.png" class="img-home" alt="banner img">
+                <img src="./img/bg.png" class="img-home" alt="banner img">
               </div>
             </div>
             <div class="col-lg-5 col-md-7">
@@ -98,7 +98,7 @@
             </div>
           </div>
           <div class="col-lg-6">
-            <img src="/img/bg.avif" class="img-about" alt="img">
+            <img src="./img/bg.avif" class="img-about" alt="img">
           </div>
         </div>
       </div>
@@ -120,7 +120,7 @@
                 <div class="col-lg-4 col-md-6">
 
                   <div class="card card-product">
-                    <img src="/img/metal-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img/metal-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Metal Chess Piece</h5>
                       <p class="card-text">These materials offer a 
@@ -134,7 +134,7 @@
 
                 <div class="col-lg-4 col-md-6">
                   <div class="card card-product">
-                    <img src="/img//glass-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img//glass-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Glass Chess Piece</h5>
                       <p class="card-text">The glass pieces are usually frosted and transparent, giving them a beautiful and ethereal appearance.</p>
@@ -146,7 +146,7 @@
 
                 <div class="col-lg-4 col-md-6">
                   <div class="card card-product">
-                    <img src="/img/wood-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img/wood-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Wood Chess Piece</h5>
                       <p class="card-text">The chess pieces are carefully 
@@ -169,7 +169,7 @@
                 <div class="col-lg-4 col-md-6">
 
                   <div class="card card-product">
-                    <img src="/img/colored-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img/colored-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Plastic Colored Chess Piece</h5>
                       <p class="card-text">A colored chess piece is a piece associated 
@@ -184,7 +184,7 @@
                 <div class="col-lg-4 col-md-6">
 
                   <div class="card card-product">
-                    <img src="/img/plastic-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img/plastic-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Plastic Chess Piece</h5>
                       <p class="card-text">Plastic Chess Pieces are affordable 
@@ -197,7 +197,7 @@
                 <div class="col-lg-4 col-md-6">
 
                   <div class="card card-product">
-                    <img src="/img/luxury-type.png" class="card-img-top img-card" alt="...">
+                    <img src="./img/luxury-type.png" class="card-img-top img-card" alt="...">
                     <div class="card-body">
                       <h5 class="card-title">Luxury Chess Piece</h5>
                       <p class="card-text">Luxury chess pieces often feature intricate and detailed designs. Skilled artisans create these pieces.</p>
@@ -252,7 +252,7 @@
                     <div class="col-lg-6 col-md-12 my-2">
                       <div class="container-content">
                         <div class="img-client">
-                          <img src="/img/people1.avif" class="image-clients" alt="">
+                          <img src="./img/people1.avif" class="image-clients" alt="">
                         </div>
 
                         <div class="icons-starts">
@@ -273,7 +273,7 @@
                     <div class="col-lg-6 col-md-12 my-2">
                       <div class="container-content">
                         <div class="img-client">
-                          <img src="/img/people2.jpg" class="image-clients" alt="">
+                          <img src="./img/people2.jpg" class="image-clients" alt="">
                         </div>
 
                         <div class="icons-starts">
@@ -301,7 +301,7 @@
                     <div class="col-lg-6 col-md-12 my-2">
                       <div class="container-content">
                         <div class="img-client">
-                          <img src="/img/people3.jpg" class="image-clients" alt="">
+                          <img src="./img/people3.jpg" class="image-clients" alt="">
                         </div>
 
                         <div class="icons-starts">
@@ -322,7 +322,7 @@
                     <div class="col-lg-6 col-md-12 my-2">
                       <div class="container-content">
                         <div class="img-client">
-                          <img src="/img/people4.jpg" class="image-clients" alt="">
+                          <img src="./img/people4.jpg" class="image-clients" alt="">
                         </div>
 
                         <div class="icons-starts">

--- a/style.css
+++ b/style.css
@@ -270,6 +270,9 @@ transition: 0.4s ease-in-out
 }
 .img-card{
   height: 190px !important;
+  width: 100% !important;
+  object-fit: contain;
+  margin: 0 auto;
 }
 .card-title{
   font-size: 15px;
@@ -531,4 +534,10 @@ footer{
 }
 .para-footer{
   margin: 0px 0px;
+}
+
+@media only screen and (max-width: 480px){
+  .card-product{
+    margin-bottom: 10px;
+  }
 }


### PR DESCRIPTION
**Technical Notes**

- margin: 0 auto = used for centering containers if display = inline-block in CSS
- object-fit: contain to resize proper image proportion in declared container size
- After PR merge run git pull

![image](https://github.com/zhyzhyito/Chess-Website/assets/11263582/1ceed264-8231-441e-a5a1-aedd21b16242)

